### PR TITLE
RGW Support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ def create_vmdk(name, size)
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-config.vm.box = 'nwl/centos7'
+config.vm.box = 'ceph/centos7'
 config.ssh.pty = true
 config.ssh.insert_key = false # workaround for https://github.com/mitchellh/vagrant/issues/5048
 

--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -1,11 +1,12 @@
 [global]
+# debug ms = 1
+# debug rgw = 20
   auth cluster required = cephx
   auth service required = cephx
   auth client required = cephx
   fsid = {{ fsid }}
   cluster network = {{ cluster_network }}
   public network = {{ public_network }}
-
   osd pool default pg num = {{ pool_default_pg_num }}
   osd pool default pgp num = {{ pool_default_pgp_num }}
 
@@ -33,3 +34,10 @@
   osd mkfs type = {{ osd_mkfs_type }}
   osd journal size = {{ journal_size }}
 
+############### RGW #################
+
+[client.radosgw.gateway]
+  rgw frontends = "civetweb port=80"
+  keyring = /etc/ceph/ceph.client.radosgw.keyring
+  host = {{ groups.mons.0 }}
+  log file = /var/log/radosgw/client.radosgw.gateway-node1.log

--- a/roles/mons/tasks/main.yml
+++ b/roles/mons/tasks/main.yml
@@ -48,6 +48,7 @@
     - /etc/ceph/ceph.conf
     - /etc/ceph/ceph.client.admin.keyring
 
+###
 
 - name: Cloning ceph-dash from github
   git: repo=git://github.com/Crapworks/ceph-dash.git dest=/etc/ceph/ceph-dash accept_hostkey=yes
@@ -60,4 +61,25 @@
   async: 360000
   poll: 0
 
+###
 
+- name: Install RGW
+  command: yum -y install ceph-radosgw
+
+- name: Creating RGW keyring
+  command: ceph-authtool --create-keyring /etc/ceph/ceph.client.radosgw.keyring
+
+- name: Setting RGW keyring persmissions
+  file: path=/etc/ceph/ceph.client.radosgw.keyring mode=0600 owner=root group=root
+
+- name: Generate key for RGW instance
+  command: ceph-authtool /etc/ceph/ceph.client.radosgw.keyring -n client.radosgw.gateway --gen-key
+
+- name: Add capabilities to RGW key
+  command: ceph-authtool -n client.radosgw.gateway --cap osd 'allow rwx' --cap mon 'allow rwx' /etc/ceph/ceph.client.radosgw.keyring
+
+- name: Add RGW key to cluster
+  command: ceph -k /etc/ceph/ceph.client.admin.keyring auth add client.radosgw.gateway -i /etc/ceph/ceph.client.radosgw.keyring
+
+- name: Start RGW
+  command: systemctl start ceph-radosgw


### PR DESCRIPTION
RGW will now be installed on the monitor.
The Vagrant box is now hosted in the ceph/ namespace.
Tested on 14.04 and OSX.
